### PR TITLE
chore: bump SwiftFormat to 0.61.0

### DIFF
--- a/Mintfile
+++ b/Mintfile
@@ -1,2 +1,2 @@
-nicklockwood/SwiftFormat@0.60.1
+nicklockwood/SwiftFormat@0.61.0
 kiliankoe/swift-outdated


### PR DESCRIPTION
Bumps SwiftFormat from 0.60.1 to 0.61.0. No formatting changes required.