### PR TITLE
refactor!: typed GraphQL variables + drop DecodableEquatableSendable

### DIFF
--- a/Sources/BrzzUtils/GraphQL/GraphQL+Dictionary.swift
+++ b/Sources/BrzzUtils/GraphQL/GraphQL+Dictionary.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-extension GraphQL {
-	public typealias Dictionary = [String: any Sendable]
-}

--- a/Sources/BrzzUtils/GraphQL/GraphQL+Envelope.swift
+++ b/Sources/BrzzUtils/GraphQL/GraphQL+Envelope.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension GraphQL {
+	/// Wire-format envelope sent to a GraphQL endpoint: the operation string and its variables.
+	public struct Envelope<Variables: Encodable>: Encodable {
+		public let query: String
+		public let variables: Variables
+
+		public init(query: String, variables: Variables) {
+			self.query = query
+			self.variables = variables
+		}
+
+		public init<Request: GraphQL.Request>(_ request: Request) where Request.Variables == Variables {
+			self.init(query: Request.query.stringValue, variables: request.variables)
+		}
+	}
+}

--- a/Sources/BrzzUtils/GraphQL/GraphQL+NoVariables.swift
+++ b/Sources/BrzzUtils/GraphQL/GraphQL+NoVariables.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension GraphQL {
+	public struct NoVariables: Encodable, Sendable {
+		public init() {}
+	}
+}

--- a/Sources/BrzzUtils/GraphQL/GraphQL+Request.swift
+++ b/Sources/BrzzUtils/GraphQL/GraphQL+Request.swift
@@ -2,8 +2,9 @@ import Foundation
 
 extension GraphQL {
 	public protocol Request {
-		associatedtype Response: Decodable, Sendable
+		associatedtype Variables: Encodable & Sendable
+		associatedtype Response: Decodable & Sendable
 		static var query: GraphQL.Query { get }
-		var variables: GraphQL.Dictionary { get }
+		var variables: Variables { get }
 	}
 }

--- a/Sources/BrzzUtils/Types/DecodableEquatableSendable.swift
+++ b/Sources/BrzzUtils/Types/DecodableEquatableSendable.swift
@@ -1,3 +1,0 @@
-import Foundation
-
-public typealias DecodableEquatableSendable = Decodable & Equatable & Sendable


### PR DESCRIPTION
## Summary

Two breaking refactors on the GraphQL layer and shared types:

- **`GraphQL.Request` now takes a typed `Variables: Encodable & Sendable`** instead of the old heterogeneous \`[String: any Sendable]\` dictionary. Adds \`GraphQL.Envelope\` (the wire-format \`{ query, variables }\` wrapper) and \`GraphQL.NoVariables\` (for variable-less queries). This closes the \`__SwiftValue\` / \`JSONSerialization\` crash class — consumers can now move to \`JSONEncoder\` and get compile-time checks that every GraphQL operation variable is supplied.
- **Removed \`DecodableEquatableSendable\` typealias.** Conforming types spell the protocol composition directly.

## Breaking changes

- \`GraphQL.Dictionary\` is gone. Every \`GraphQL.Request\` conformer must declare a concrete \`Variables\` type (or \`GraphQL.NoVariables\`).
- \`DecodableEquatableSendable\` is gone. Spell it out at each conformer (\`Decodable, Equatable, Sendable\`).

Release should bump to the next major (2.0.0).

## Test plan

- [x] \`just build\` green locally.
- [x] Verified consumer app (SimpleTrackerForAniList) compiles and full test suite (\`just test\`) passes against this branch via a local path override.