### PR TITLE
feat(graphql): expose public init on NoResponse

### DIFF
--- a/Sources/BrzzUtils/GraphQL/GraphQL+Response.swift
+++ b/Sources/BrzzUtils/GraphQL/GraphQL+Response.swift
@@ -6,5 +6,7 @@ extension GraphQL {
 		public let errors: [Error]? // swiftlint:disable:this discouraged_optional_collection
 	}
 
-	public struct NoResponse: Decodable, Sendable {}
+	public struct NoResponse: Decodable, Sendable {
+		public init() {}
+	}
 }


### PR DESCRIPTION
## Summary
- Adds `public init()` to `GraphQL.NoResponse`, mirroring `GraphQL.NoVariables`.
- Lets downstream tests construct the placeholder directly instead of force-decoding `{}` through `JSONDecoder`.

## Context
Unblocks brzzdev/SimpleTrackerForAniList#81, where test fixtures currently do:

```swift
// swiftlint:disable:next force_try
nonisolated private static let noopDeleteResponse = try! JSONDecoder().decode(
    MediaListEntry.DeleteListEntry.Response.self,
    from: Data("{}".utf8),
)
```

After this lands and a new tag is cut, those fixtures collapse to `MediaListEntry.DeleteListEntry.Response()`.

## Test plan
- [x] `just test` — all suites pass.