### PR TITLE
feat: add failed case to LoadingState

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
 	dependencies: [
 		.package(
 			url: "https://github.com/pointfreeco/swift-composable-architecture",
-			from: "1.25.5",
+			from: "1.26.0",
 		),
 		.package(
 			url: "https://github.com/pointfreeco/swift-snapshot-testing",

--- a/Package.swift
+++ b/Package.swift
@@ -74,3 +74,20 @@ let package = Package(
 		),
 	],
 )
+
+for target in package.targets {
+	target.swiftSettings = target.swiftSettings ?? []
+	target.swiftSettings?.append(contentsOf: [
+		.enableUpcomingFeature("ExistentialAny"),
+		.enableUpcomingFeature("ImmutableWeakCaptures"),
+		.enableUpcomingFeature("InferIsolatedConformances"),
+		.enableUpcomingFeature("InternalImportsByDefault"),
+		.enableUpcomingFeature("MemberImportVisibility"),
+		.enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+	])
+	#if compiler(>=6.4)
+	target.swiftSettings?.append(contentsOf: [
+		.treatAllWarnings(as: .error),
+	])
+	#endif
+}

--- a/Sources/BrzzTestUtils/SnapshotTesting+Locale.swift
+++ b/Sources/BrzzTestUtils/SnapshotTesting+Locale.swift
@@ -1,6 +1,6 @@
 #if canImport(UIKit)
-import SnapshotTesting
-import SwiftUI
+public import SnapshotTesting
+public import SwiftUI
 import UIKit
 
 extension Snapshotting where Value == UIViewController, Format == UIImage {
@@ -61,8 +61,8 @@ extension View {
 
 #if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
-import SnapshotTesting
-import SwiftUI
+public import SnapshotTesting
+public import SwiftUI
 
 extension Snapshotting where Value == NSView, Format == NSImage {
 	/// An image snapshotting strategy that appends the current locale identifier

--- a/Sources/BrzzUtils/Dependencies/Dep+OSLogStore.swift
+++ b/Sources/BrzzUtils/Dependencies/Dep+OSLogStore.swift
@@ -1,5 +1,5 @@
-import ComposableArchitecture
-import OSLog
+public import ComposableArchitecture
+public import OSLog
 
 extension DependencyValues {
 	public var osLogStore: OSLogStore.DependencyKey {

--- a/Sources/BrzzUtils/Dependencies/UserDefaults/Dep+UserDefaults.swift
+++ b/Sources/BrzzUtils/Dependencies/UserDefaults/Dep+UserDefaults.swift
@@ -1,6 +1,6 @@
-import Dependencies
+public import Dependencies
 import DependenciesMacros
-import Foundation
+public import Foundation
 
 extension DependencyValues {
 	public var userDefaults: UserDefaults.Dependency {

--- a/Sources/BrzzUtils/Dependencies/UserDefaults/Dep+UserDefaultsProvider.swift
+++ b/Sources/BrzzUtils/Dependencies/UserDefaults/Dep+UserDefaultsProvider.swift
@@ -1,6 +1,6 @@
-import Dependencies
+public import Dependencies
 import DependenciesMacros
-import Foundation
+public import Foundation
 
 extension DependencyValues {
 	public var userDefaultsProvider: UserDefaults {

--- a/Sources/BrzzUtils/Extensions/Ext+ASWebAuthenticationSession.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+ASWebAuthenticationSession.swift
@@ -1,5 +1,5 @@
-import AuthenticationServices
-import Foundation
+public import AuthenticationServices
+public import Foundation
 
 extension ASWebAuthenticationSession {
 	private final class PresentationContextProviding: NSObject,

--- a/Sources/BrzzUtils/Extensions/Ext+Color.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+Color.swift
@@ -1,5 +1,5 @@
 import Dependencies
-import SwiftUI
+public import SwiftUI
 
 extension Color {
 	public init?(hex: String?) {

--- a/Sources/BrzzUtils/Extensions/Ext+Data.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+Data.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 extension Data {
 	public var prettyPrinted: String {

--- a/Sources/BrzzUtils/Extensions/Ext+Date.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+Date.swift
@@ -1,5 +1,5 @@
 import Dependencies
-import Foundation
+public import Foundation
 
 extension Date {
 	public enum BrzzDateStyle {

--- a/Sources/BrzzUtils/Extensions/Ext+IdentifiedArray.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+IdentifiedArray.swift
@@ -1,4 +1,4 @@
-import IdentifiedCollections
+public import IdentifiedCollections
 
 extension IdentifiedArray {
 	@inlinable

--- a/Sources/BrzzUtils/Extensions/Ext+LockIsolated.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+LockIsolated.swift
@@ -1,4 +1,4 @@
-import ConcurrencyExtras
+public import ConcurrencyExtras
 import Foundation
 
 extension LockIsolated {

--- a/Sources/BrzzUtils/Extensions/Ext+Logger.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+Logger.swift
@@ -1,5 +1,5 @@
 import Foundation
-import OSLog
+public import OSLog
 
 extension Logger {
 	private static let fallbackSubsystem = "dev.brzz.unknown"
@@ -37,7 +37,7 @@ extension Logger {
 		return Logger(category: String(moduleName))
 	}
 
-	public func error(_ error: Error) {
+	public func error(_ error: any Error) {
 		self.error("\(error)")
 	}
 }

--- a/Sources/BrzzUtils/Extensions/Ext+Mutex.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+Mutex.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Synchronization
+public import Synchronization
 
 @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
 extension Mutex where Value: Numeric & Sendable {

--- a/Sources/BrzzUtils/Extensions/Ext+Tagged.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+Tagged.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Tagged
+public import Tagged
 
 extension Tagged where RawValue: FixedWidthInteger {
 	public static func random(

--- a/Sources/BrzzUtils/Extensions/Ext+TextAlignment.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+TextAlignment.swift
@@ -1,4 +1,4 @@
-import SwiftUI
+public import SwiftUI
 
 extension TextAlignment {
 	public func toAlignment() -> Alignment {

--- a/Sources/BrzzUtils/Extensions/Ext+TopLevelCoder.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+TopLevelCoder.swift
@@ -1,5 +1,5 @@
-import Combine
-import Foundation
+public import Combine
+public import Foundation
 
 extension TopLevelDecoder where Input == Data {
 	public func safeDecode<T: Decodable>(_ data: Data) -> T? {

--- a/Sources/BrzzUtils/Extensions/Ext+UIApplication.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+UIApplication.swift
@@ -1,5 +1,5 @@
 #if os(iOS)
-import UIKit
+public import UIKit
 
 extension UIApplication {
 	public var safeKeyWindow: UIWindow? {

--- a/Sources/BrzzUtils/Extensions/Ext+URLResponse.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+URLResponse.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 extension URLResponse {
 	/// The HTTP status code of the response.

--- a/Sources/BrzzUtils/Extensions/Ext+UncheckedSendable.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+UncheckedSendable.swift
@@ -1,4 +1,4 @@
-import Combine
+public import Combine
 
 extension AnyPublisher: @retroactive @unchecked Sendable where Output: Sendable,
 	Failure: Sendable {}

--- a/Sources/BrzzUtils/Extensions/Ext+View.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+View.swift
@@ -1,4 +1,4 @@
-import SwiftUI
+public import SwiftUI
 
 extension View {
 	public func alignFrame(_ alignment: TextAlignment) -> some View {

--- a/Sources/BrzzUtils/GraphQL/GraphQL+Error.swift
+++ b/Sources/BrzzUtils/GraphQL/GraphQL+Error.swift
@@ -1,4 +1,4 @@
-import Foundation
+public import Foundation
 
 extension GraphQL {
 	public struct Error: Decodable, LocalizedError {

--- a/Sources/BrzzUtils/Types/AssertionFailureView.swift
+++ b/Sources/BrzzUtils/Types/AssertionFailureView.swift
@@ -1,4 +1,4 @@
-import SwiftUI
+public import SwiftUI
 
 public struct AssertionFailureView: View {
 	public init(message: String = "") {

--- a/Sources/BrzzUtils/Types/CancelBag.swift
+++ b/Sources/BrzzUtils/Types/CancelBag.swift
@@ -1,4 +1,4 @@
-import Combine
+public import Combine
 import ConcurrencyExtras
 import Foundation
 

--- a/Sources/BrzzUtils/Types/CloseButton.swift
+++ b/Sources/BrzzUtils/Types/CloseButton.swift
@@ -1,4 +1,4 @@
-import SwiftUI
+public import SwiftUI
 
 public struct CloseButton: View {
 	public enum Style {

--- a/Sources/BrzzUtils/Types/LoadingState.swift
+++ b/Sources/BrzzUtils/Types/LoadingState.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public enum LoadingState: Equatable, Sendable {
+	case failed(message: String)
 	case firstLoad
 	case loaded
 	case refreshing
@@ -10,7 +11,7 @@ public enum LoadingState: Equatable, Sendable {
 		case .firstLoad, .refreshing:
 			true
 
-		case .loaded:
+		case .failed, .loaded:
 			false
 		}
 	}
@@ -23,5 +24,9 @@ public enum LoadingState: Equatable, Sendable {
 		} else {
 			self = .loaded
 		}
+	}
+
+	public mutating func fail(message: String) {
+		self = .failed(message: message)
 	}
 }

--- a/Sources/BrzzUtils/Types/LoadingState.swift
+++ b/Sources/BrzzUtils/Types/LoadingState.swift
@@ -16,6 +16,10 @@ public enum LoadingState: Equatable, Sendable {
 		}
 	}
 
+	/// Transitions to `.refreshing` while loading — or stays on `.firstLoad` when there's no data
+	/// yet — and to `.loaded` when finished. It never re-enters `.firstLoad` or `.failed`: to show a
+	/// full-screen spinner again after a failure, assign `.firstLoad` explicitly rather than calling
+	/// this.
 	public mutating func setLoading(_ loading: Bool) {
 		if loading {
 			guard self != .firstLoad else { return }

--- a/Tests/BrzzUtilsTests/LoadingStateTests.swift
+++ b/Tests/BrzzUtilsTests/LoadingStateTests.swift
@@ -15,37 +15,47 @@ struct LoadingStateTests {
 		// GIVEN
 		var firstLoad = LoadingState.firstLoad
 		var loaded = LoadingState.loaded
+		// Recovering from a failure never returns to `.firstLoad`.
+		var failed = LoadingState.failed(message: "boom")
 
 		// WHEN
 		firstLoad.setLoading(true)
 		loaded.setLoading(true)
+		failed.setLoading(true)
 
 		// THEN
 		#expect(firstLoad == .firstLoad)
 		#expect(loaded == .refreshing)
+		#expect(failed == .refreshing)
 	}
 
 	@Test
 	func setLoadingFalseMarksLoaded() {
 		// GIVEN
-		var state = LoadingState.refreshing
+		var refreshing = LoadingState.refreshing
+		var failed = LoadingState.failed(message: "boom")
 
 		// WHEN
-		state.setLoading(false)
+		refreshing.setLoading(false)
+		failed.setLoading(false)
 
 		// THEN
-		#expect(state == .loaded)
+		#expect(refreshing == .loaded)
+		#expect(failed == .loaded)
 	}
 
 	@Test
-	func failStoresTheMessage() {
+	func failStoresTheMessageFromAnyState() {
 		// GIVEN
-		var state = LoadingState.firstLoad
+		var firstLoad = LoadingState.firstLoad
+		var loaded = LoadingState.loaded
 
 		// WHEN
-		state.fail(message: "Network error")
+		firstLoad.fail(message: "Network error")
+		loaded.fail(message: "Network error")
 
 		// THEN
-		#expect(state == .failed(message: "Network error"))
+		#expect(firstLoad == .failed(message: "Network error"))
+		#expect(loaded == .failed(message: "Network error"))
 	}
 }

--- a/Tests/BrzzUtilsTests/LoadingStateTests.swift
+++ b/Tests/BrzzUtilsTests/LoadingStateTests.swift
@@ -1,0 +1,51 @@
+@testable import BrzzUtils
+import Testing
+
+struct LoadingStateTests {
+	@Test
+	func isLoadingIsTrueOnlyWhileFetching() {
+		#expect(LoadingState.firstLoad.isLoading)
+		#expect(LoadingState.refreshing.isLoading)
+		#expect(!LoadingState.loaded.isLoading)
+		#expect(!LoadingState.failed(message: "boom").isLoading)
+	}
+
+	@Test
+	func setLoadingTrueKeepsFirstLoadButOtherwiseRefreshes() {
+		// GIVEN
+		var firstLoad = LoadingState.firstLoad
+		var loaded = LoadingState.loaded
+
+		// WHEN
+		firstLoad.setLoading(true)
+		loaded.setLoading(true)
+
+		// THEN
+		#expect(firstLoad == .firstLoad)
+		#expect(loaded == .refreshing)
+	}
+
+	@Test
+	func setLoadingFalseMarksLoaded() {
+		// GIVEN
+		var state = LoadingState.refreshing
+
+		// WHEN
+		state.setLoading(false)
+
+		// THEN
+		#expect(state == .loaded)
+	}
+
+	@Test
+	func failStoresTheMessage() {
+		// GIVEN
+		var state = LoadingState.firstLoad
+
+		// WHEN
+		state.fail(message: "Network error")
+
+		// THEN
+		#expect(state == .failed(message: "Network error"))
+	}
+}


### PR DESCRIPTION
## What changed
Adds `case failed(message: String)` to `LoadingState`, plus a `fail(message:)`
mutating helper. `isLoading` returns `false` for `.failed`.

## Why
Lets a load state carry its failure message inline, so consumers can drop the
parallel `loadErrorMessage: String?` field. This is the shared type the app's
load-state unification migrates every feature onto (replacing
`ProfileLoadingState` and ad-hoc `isLoading: Bool`).

## Test plan
- [x] `just test` green (new `LoadingStateTests` covers `isLoading`,
  `setLoading`, and `fail`)

---
> Stacked on #44 (Xcode 27 build settings) — base is `build/enable-upcoming-features`; retarget to `main` once #44 merges.
