### PR TITLE
ci: run on macos-26 with iPhone 17 Pro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ concurrency:
 jobs:
   test:
     name: Test ${{ matrix.platform }}
-    runs-on: macos-15
+    runs-on: macos-26
     strategy:
       matrix:
         platform: [iOS, macOS]
         include:
           - platform: iOS
-            destination: "platform=iOS Simulator,name=iPhone 16 Pro,OS=latest"
+            destination: "platform=iOS Simulator,name=iPhone 17 Pro,OS=latest"
           - platform: macOS
             destination: "platform=macOS"
 


### PR DESCRIPTION
## What changed
- Bump the CI runner from `macos-15` to `macos-26`.
- Switch the iOS destination to `iPhone 17 Pro`.

## Why
`macos-15`'s `latest-stable` Xcode ships Swift 6.2.4, which can't parse this
package's `swift-tools-version: 6.3` manifest — CI fails before it can resolve
or build. `macos-26` provides a Swift 6.3+ toolchain, and `iPhone 17 Pro`
matches the simulators on that image.

## Things to look out for
Merge this first; #44 and #45 then rebase onto it so their CI runs on the
6.3-capable toolchain.