### PR TITLE
feat(snapshot): pin appearance and Dynamic Type as explicit axes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,20 +30,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      # Key the cache to the resolved Xcode build so a `latest-stable` bump can
+      # never restore DerivedData whose SwiftSyntax macro binaries were compiled
+      # against the previous toolchain (they fail with "unable to resolve Swift
+      # module dependency to a compatible module"). Runs after Setup Xcode so the
+      # version is known before the cache is restored.
+      - name: Capture Xcode version
+        run: echo "XCODE_BUILD=$(xcodebuild -version | tail -n1 | awk '{print $NF}')" >> "$GITHUB_ENV"
+
       - name: Cache Xcode
         uses: actions/cache@v5
         with:
           path: |
             ~/Library/Developer/Xcode/DerivedData
             ~/Library/Caches/org.swift.swiftpm
-          key: ${{ runner.os }}-${{ matrix.platform }}-xcode-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          key: ${{ runner.os }}-${{ matrix.platform }}-xcode-${{ env.XCODE_BUILD }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.platform }}-xcode-
-
-      - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
+            ${{ runner.os }}-${{ matrix.platform }}-xcode-${{ env.XCODE_BUILD }}-
 
       - name: Install brew
         run: brew bundle

--- a/Sources/BrzzTestUtils/SnapshotTesting+Locale.swift
+++ b/Sources/BrzzTestUtils/SnapshotTesting+Locale.swift
@@ -1,3 +1,33 @@
+#if canImport(UIKit) || canImport(AppKit)
+public import SwiftUI
+
+/// Builds the reference filename for a snapshot from the axes it was rendered at.
+///
+/// `testName` arrives as `#function`, which reads `foo()` for a plain test and
+/// `foo(scheme:)` for a parameterised one; truncating at the first `(` makes both
+/// yield the same base, so a suite can be parameterised without renaming its
+/// references.
+///
+/// The colour scheme is always encoded, so no filename implicitly means light.
+/// Every other axis is encoded only when it differs from its default, so adding a
+/// future axis renames nothing that does not use it.
+///
+/// Tokens come from the enum case names (`light`, `accessibility2`), which is why
+/// changing an axis' default is a corpus-wide rename.
+func snapshotName(
+	testName: String,
+	scheme: ColorScheme,
+	dynamicTypeSize: DynamicTypeSize,
+) -> String {
+	var name = String(testName.prefix { $0 != "(" })
+	name += "_\(scheme)"
+	if dynamicTypeSize != .large {
+		name += "_\(dynamicTypeSize)"
+	}
+	return name
+}
+#endif
+
 #if canImport(UIKit)
 public import SnapshotTesting
 public import SwiftUI
@@ -15,12 +45,10 @@ extension Snapshotting where Value == UIViewController, Format == UIImage {
 		on config: ViewImageConfig,
 		locale: Locale = Locale(identifier: "en_GB"),
 		perceptualPrecision: Float = 1,
-		traits: UITraitCollection = UITraitCollection(),
 	) -> Snapshotting {
 		var strategy: Snapshotting = .image(
 			on: config,
 			perceptualPrecision: perceptualPrecision,
-			traits: traits,
 		)
 		strategy.pathExtension = locale.identifier + ".png"
 		return strategy
@@ -32,12 +60,22 @@ extension View {
 	///
 	/// Wraps the view in a `UIHostingController` and uses `imageWithLocale`
 	/// so the reference filename is keyed to a fixed locale (default `en_GB`).
+	///
+	/// Appearance and Dynamic Type are applied through the SwiftUI environment and
+	/// are *always* applied, so a snapshot never renders against whatever ambient
+	/// state the shared snapshot window happens to hold. Deliberately there is no
+	/// `traits:` escape hatch: `UITraitCollection(userInterfaceStyle:)` sets
+	/// `overrideUserInterfaceStyle` on that shared window, which outlives the
+	/// assertion and leaks into later suites' references.
+	///
+	/// The reference filename encodes the axes — see `snapshotName(testName:…)`.
 	@MainActor
 	public func assertSnapshotWithLocale(
 		on config: ViewImageConfig = .iPhone13,
+		dynamicTypeSize: DynamicTypeSize = .large,
 		locale: Locale = Locale(identifier: "en_GB"),
 		perceptualPrecision: Float = 1,
-		traits: UITraitCollection = UITraitCollection(),
+		scheme: ColorScheme = .light,
 		record: SnapshotTestingConfiguration.Record? = nil,
 		fileID: StaticString = #fileID,
 		file: StaticString = #filePath,
@@ -45,18 +83,25 @@ extension View {
 		line: UInt = #line,
 		column: UInt = #column,
 	) {
+		let rootView =
+			environment(\.colorScheme, scheme)
+				.dynamicTypeSize(dynamicTypeSize)
+
 		assertSnapshot(
-			of: UIHostingController(rootView: self),
+			of: UIHostingController(rootView: rootView),
 			as: .imageWithLocale(
 				on: config,
 				locale: locale,
 				perceptualPrecision: perceptualPrecision,
-				traits: traits,
 			),
 			record: record,
 			fileID: fileID,
 			file: file,
-			testName: testName,
+			testName: snapshotName(
+				testName: testName,
+				scheme: scheme,
+				dynamicTypeSize: dynamicTypeSize,
+			),
 			line: line,
 			column: column,
 		)
@@ -87,10 +132,16 @@ extension View {
 	///
 	/// Wraps the view in an `NSHostingView` and uses `imageWithLocale`
 	/// so the reference filename is keyed to a fixed locale (default `en_GB`).
+	///
+	/// Appearance and Dynamic Type are applied through the SwiftUI environment and
+	/// are always applied, matching the UIKit overload so both platforms key their
+	/// references the same way.
 	@MainActor
 	public func assertSnapshotWithLocale(
+		dynamicTypeSize: DynamicTypeSize = .large,
 		locale: Locale = Locale(identifier: "en_GB"),
 		perceptualPrecision: Float = 1,
+		scheme: ColorScheme = .light,
 		record: SnapshotTestingConfiguration.Record? = nil,
 		fileID: StaticString = #fileID,
 		file: StaticString = #filePath,
@@ -98,14 +149,21 @@ extension View {
 		line: UInt = #line,
 		column: UInt = #column,
 	) {
-		let view = NSHostingView(rootView: self)
+		let rootView =
+			environment(\.colorScheme, scheme)
+				.dynamicTypeSize(dynamicTypeSize)
+
 		assertSnapshot(
-			of: view,
+			of: NSHostingView(rootView: rootView),
 			as: .imageWithLocale(locale: locale, perceptualPrecision: perceptualPrecision),
 			record: record,
 			fileID: fileID,
 			file: file,
-			testName: testName,
+			testName: snapshotName(
+				testName: testName,
+				scheme: scheme,
+				dynamicTypeSize: dynamicTypeSize,
+			),
 			line: line,
 			column: column,
 		)


### PR DESCRIPTION
## What changed

Snapshot rendering inputs are now **named parameters applied through the SwiftUI environment**, and are *always* applied:

| Axis | Parameter | Default |
|---|---|---|
| Locale | `locale:` | `en_GB` *(existing)* |
| Appearance | `scheme:` | `.light` **(new)** |
| Dynamic Type | `dynamicTypeSize:` | `.large` **(new)** |

`traits:` is **removed** from both `assertSnapshotWithLocale` and `imageWithLocale`. `perceptualPrecision` now defaults to `1` rather than `0.98`.

Reference filenames encode the axes — colour scheme always, other axes only when they deviate:

```
loadedSessions_light.1.en_GB.png
loadedSessions_dark.1.en_GB.png
driverStandings_light_accessibility2.1.en_GB.png
```

## Why

A snapshot that doesn't pin an axis doesn't fall back to a sensible default — it renders against whatever ambient state the shared snapshot window happens to hold, which makes the corpus order-dependent.

`traits:` was worse than merely unhelpful here. `UITraitCollection(userInterfaceStyle: .dark)` is applied by setting `overrideUserInterfaceStyle` on the *shared* snapshot window, and that override outlives the assertion — so a dark test could leak into a later suite's light-mode reference. The failure is invisible in a passing run and surfaces later as unexplained diffs. Removing the parameter makes that mechanism unreachable rather than relying on review to catch it.

Both new axes are **defaulted rather than required**, matching how `locale` was already handled: determinism comes from the helper always applying the axis, not from forcing every caller to restate it.

## Filename derivation

`#function` is truncated at the first `(`, so `foo()` and `foo(scheme:)` yield the same base. That's what lets a suite adopt `@Test(arguments:)` over an axis without renaming its references — which matters because parameterised cases run in parallel and share a `#function`, so relying on swift-snapshot-testing's positional `.1`/`.2` counter would race.

Scheme is encoded unconditionally so no filename implicitly means light; everything else only on deviation, so adding a future axis (layout direction, device size) renames nothing that doesn't use it.

## Verification

Validated against SimpleF1, the only consumer that calls this API (0 call sites in the other four dependent repos):

- **125 tests across 9 suites pass** at `perceptualPrecision: 1`, with zero mismatches across repeated runs
- **59 of 85 reference images are byte-identical** after renaming — proving the filename change is pixel-neutral
- The other 26 changed for one understood reason: pinning Dynamic Type shifts text metrics a few pixels in full-screen `NavigationStack` views. Fixed-frame widget canvases are unaffected, which is why all 56 widget references passed unchanged

## Breaking

`traits:` is gone. Use `scheme:` for appearance and `dynamicTypeSize:` for Dynamic Type. Existing references need a scheme suffix. No other consumer calls this API, so the blast radius is limited to SimpleF1, which migrates in tandem.
