### PR TITLE
ci: only save the Xcode cache on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,20 @@ jobs:
       - name: Capture Xcode version
         run: echo "XCODE_BUILD=$(xcodebuild -version | tail -n1 | awk '{print $NF}')" >> "$GITHUB_ENV"
 
-      - name: Cache Xcode
-        uses: actions/cache@v6
+      # Restore on every run, but only save on main. A cache written on a PR ref
+      # is readable solely by that PR, while one written on main is readable by
+      # every branch — so PR saves cost ~31s per matrix leg and ~1GB of quota to
+      # populate an entry almost nothing reads. Measured over a fortnight of
+      # runs, no run ever restored a refs/pull/* entry; PRs were served by
+      # main's cache, and each merge then re-saved the same key anyway.
+      - name: Restore Xcode cache
+        id: cache
+        uses: actions/cache/restore@v6
         with:
           path: |
             ~/Library/Developer/Xcode/DerivedData
             ~/Library/Caches/org.swift.swiftpm
-          key: ${{ runner.os }}-${{ matrix.platform }}-xcode-${{ env.XCODE_BUILD }}-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          key: ${{ runner.os }}-${{ matrix.platform }}-xcode-${{ env.XCODE_BUILD }}-${{ hashFiles('Package.swift') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.platform }}-xcode-${{ env.XCODE_BUILD }}-
 
@@ -67,3 +74,14 @@ jobs:
           -derivedDataPath ~/Library/Developer/Xcode/DerivedData \
           -resultBundlePath TestResults-${{ matrix.platform }} \
           | xcbeautify
+
+      # Must run after the build, and only when the exact key was missed —
+      # actions/cache/save has no restore step to skip itself.
+      - name: Save Xcode cache
+        if: github.ref == 'refs/heads/main' && steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-${{ matrix.platform }}-xcode-${{ env.XCODE_BUILD }}-${{ hashFiles('Package.swift') }}


### PR DESCRIPTION
## Why

A cache written on a PR ref is readable **only by that PR**, while one written on
`main` is readable by every branch. So PR saves were paying to populate entries that
nothing reads.

Measured over a fortnight of runs:

- **No run ever restored a `refs/pull/*` entry.** PRs were served by main's cache —
  the four renovate PRs on 21 Jul all restored main-scoped entries.
- Run `29876504502` (a PR) saved a key, and the merge-to-main run `29876756245` then
  **re-saved the identical key**, because main can't read PR scope.
- Cost: `Post Cache Xcode` on missing PR runs averaged **31s per matrix leg** (~62s
  runner-time, ~2.1GB written per PR run). This is what pushed the repo to **12.66GB**
  against the 10GB limit, causing it to evict entries it wanted.

## What changed

`actions/cache` split into `actions/cache/restore` (every run) and
`actions/cache/save` (gated on `main`, and only when the exact key missed). The save
step must sit *after* the build, since it has no restore step to skip itself.

Also dropped `Package.resolved` from the key. It's gitignored and absent from `main`
(`git ls-tree origin/main` confirms), so `hashFiles('Package.swift', 'Package.resolved')`
only ever hashed `Package.swift` — the second pattern was dead.

## What is not changing

Restores still happen on every run, and the cache is emphatically worth keeping —
measured on the `Build and Test` step:

| leg | cold | restore-keys hit | exact hit |
|---|---|---|---|
| iOS | 278s | 162s | 110s |
| macOS | 176s | 86s | 84s |

That's ~157s of wall clock per run on an exact hit. This PR only stops the redundant
writes.

## Worth a separate look

The build invokes `xcodebuild` directly, while this repo's `CLAUDE.md` says to build
and test via `just`. Pre-existing and out of scope here, but flagging it.
