### PR TITLE
fix(LoadingState)!: reload without content after .failed, rename .firstLoad

### DIFF
--- a/Sources/BrzzUtils/Types/LoadingState.swift
+++ b/Sources/BrzzUtils/Types/LoadingState.swift
@@ -2,13 +2,13 @@ import Foundation
 
 public enum LoadingState: Equatable, Sendable {
 	case failed(message: String)
-	case firstLoad
 	case loaded
+	case loadingWithoutContent
 	case refreshing
 
 	public var isLoading: Bool {
 		switch self {
-		case .firstLoad, .refreshing:
+		case .loadingWithoutContent, .refreshing:
 			true
 
 		case .failed, .loaded:
@@ -16,9 +16,9 @@ public enum LoadingState: Equatable, Sendable {
 		}
 	}
 
-	/// Transitions to `.refreshing` while loading, or to `.firstLoad` when there's nothing on screen
-	/// to keep — that's `.firstLoad` itself and `.failed`. Finishing lands on `.loaded`, and this
-	/// never re-enters `.failed`.
+	/// Transitions to `.refreshing` while loading, or stays on `.loadingWithoutContent` when there's
+	/// nothing on screen to keep — which includes retrying out of `.failed`. Finishing lands on
+	/// `.loaded`, and this never re-enters `.failed`.
 	///
 	/// Retrying out of `.failed` shows a full-screen spinner rather than an inline one, because
 	/// `.failed` should only ever be entered with nothing to show: a refresh that fails over
@@ -26,8 +26,8 @@ public enum LoadingState: Equatable, Sendable {
 	public mutating func setLoading(_ loading: Bool) {
 		if loading {
 			switch self {
-			case .failed, .firstLoad:
-				self = .firstLoad
+			case .failed, .loadingWithoutContent:
+				self = .loadingWithoutContent
 
 			case .loaded, .refreshing:
 				self = .refreshing

--- a/Sources/BrzzUtils/Types/LoadingState.swift
+++ b/Sources/BrzzUtils/Types/LoadingState.swift
@@ -16,15 +16,22 @@ public enum LoadingState: Equatable, Sendable {
 		}
 	}
 
-	/// Transitions to `.refreshing` while loading — or stays on `.firstLoad` when there's no data
-	/// yet — and to `.loaded` when finished. It never re-enters `.firstLoad` or `.failed`: to show a
-	/// full-screen spinner again after a failure, assign `.firstLoad` explicitly rather than calling
-	/// this.
+	/// Transitions to `.refreshing` while loading, or to `.firstLoad` when there's nothing on screen
+	/// to keep — that's `.firstLoad` itself and `.failed`. Finishing lands on `.loaded`, and this
+	/// never re-enters `.failed`.
+	///
+	/// Retrying out of `.failed` shows a full-screen spinner rather than an inline one, because
+	/// `.failed` should only ever be entered with nothing to show: a refresh that fails over
+	/// already-loaded content is expected to leave that content on screen instead of failing.
 	public mutating func setLoading(_ loading: Bool) {
 		if loading {
-			guard self != .firstLoad else { return }
+			switch self {
+			case .failed, .firstLoad:
+				self = .firstLoad
 
-			self = .refreshing
+			case .loaded, .refreshing:
+				self = .refreshing
+			}
 		} else {
 			self = .loaded
 		}

--- a/Tests/BrzzUtilsTests/LoadingStateTests.swift
+++ b/Tests/BrzzUtilsTests/LoadingStateTests.swift
@@ -11,22 +11,25 @@ struct LoadingStateTests {
 	}
 
 	@Test
-	func setLoadingTrueKeepsFirstLoadButOtherwiseRefreshes() {
+	func setLoadingTrueRefreshesOnlyWhenThereIsContentToKeep() {
 		// GIVEN
 		var firstLoad = LoadingState.firstLoad
 		var loaded = LoadingState.loaded
-		// Recovering from a failure never returns to `.firstLoad`.
+		var refreshing = LoadingState.refreshing
+		// A failure is only ever entered with nothing on screen, so retrying is a first load.
 		var failed = LoadingState.failed(message: "boom")
 
 		// WHEN
 		firstLoad.setLoading(true)
 		loaded.setLoading(true)
+		refreshing.setLoading(true)
 		failed.setLoading(true)
 
 		// THEN
 		#expect(firstLoad == .firstLoad)
 		#expect(loaded == .refreshing)
-		#expect(failed == .refreshing)
+		#expect(refreshing == .refreshing)
+		#expect(failed == .firstLoad)
 	}
 
 	@Test

--- a/Tests/BrzzUtilsTests/LoadingStateTests.swift
+++ b/Tests/BrzzUtilsTests/LoadingStateTests.swift
@@ -4,7 +4,7 @@ import Testing
 struct LoadingStateTests {
 	@Test
 	func isLoadingIsTrueOnlyWhileFetching() {
-		#expect(LoadingState.firstLoad.isLoading)
+		#expect(LoadingState.loadingWithoutContent.isLoading)
 		#expect(LoadingState.refreshing.isLoading)
 		#expect(!LoadingState.loaded.isLoading)
 		#expect(!LoadingState.failed(message: "boom").isLoading)
@@ -13,23 +13,23 @@ struct LoadingStateTests {
 	@Test
 	func setLoadingTrueRefreshesOnlyWhenThereIsContentToKeep() {
 		// GIVEN
-		var firstLoad = LoadingState.firstLoad
+		var loadingWithoutContent = LoadingState.loadingWithoutContent
 		var loaded = LoadingState.loaded
 		var refreshing = LoadingState.refreshing
-		// A failure is only ever entered with nothing on screen, so retrying is a first load.
+		// A failure is only ever entered with nothing on screen, so retrying has no content either.
 		var failed = LoadingState.failed(message: "boom")
 
 		// WHEN
-		firstLoad.setLoading(true)
+		loadingWithoutContent.setLoading(true)
 		loaded.setLoading(true)
 		refreshing.setLoading(true)
 		failed.setLoading(true)
 
 		// THEN
-		#expect(firstLoad == .firstLoad)
+		#expect(loadingWithoutContent == .loadingWithoutContent)
 		#expect(loaded == .refreshing)
 		#expect(refreshing == .refreshing)
-		#expect(failed == .firstLoad)
+		#expect(failed == .loadingWithoutContent)
 	}
 
 	@Test
@@ -50,15 +50,15 @@ struct LoadingStateTests {
 	@Test
 	func failStoresTheMessageFromAnyState() {
 		// GIVEN
-		var firstLoad = LoadingState.firstLoad
+		var loadingWithoutContent = LoadingState.loadingWithoutContent
 		var loaded = LoadingState.loaded
 
 		// WHEN
-		firstLoad.fail(message: "Network error")
+		loadingWithoutContent.fail(message: "Network error")
 		loaded.fail(message: "Network error")
 
 		// THEN
-		#expect(firstLoad == .failed(message: "Network error"))
+		#expect(loadingWithoutContent == .failed(message: "Network error"))
 		#expect(loaded == .failed(message: "Network error"))
 	}
 }


### PR DESCRIPTION
Two changes to `LoadingState`, both about the same confusion: the state that means *nothing is on screen* was named for *when* it happens rather than *what it is*, and the transition into it was wrong.

## The transition (#59)

`setLoading(true)` sent `.failed` to `.refreshing`. Those say different things to a view: `.refreshing` means *there is content on screen and it is being updated*, the other means *there is nothing yet*. Loading out of `.failed` is always the second kind, so `.refreshing` was the wrong destination — a retry arrived in the loaded branch with empty content, which reads as "no results" unless the view adds a spinner branch to catch it.

What licenses the change is the invariant that `.failed` is only ever entered when there was nothing to show — a refresh that fails over an already-loaded list leaves it on screen. SimpleF1 enforces that on all seven screens as of brzzdev/SimpleF1#59, #117, #121 and #122.

The guard on the no-content case and the `.loaded`/`.refreshing` behaviour are unchanged, and `setLoading` still never re-enters `.failed`.

## The rename (#61)

`.firstLoad` → `.loadingWithoutContent`. The two loading cases are distinguished by whether there's content on screen, not by ordinality — `LoadStateView` in the consumers branches on exactly that — so `.firstLoad` was the odd one out in an enum where every other case names a condition.

`.loadingWithoutContent` over the shorter `.loading` deliberately: `.loading` sits one letter from `.loaded` and both are assignable, so `state.loadingState = .loaded` and `= .loading` would both compile and mean opposite things. Verbosity is the cheaper trade.

Raised by a Codex review on this PR.

## Notes

The doc comment documented the behaviour being removed, including the "assign `.firstLoad` explicitly" workaround instruction, so it's rewritten. The existing test asserted the old `.failed → .refreshing` transition; it now covers the new one and picks up the `.refreshing → .refreshing` case it was missing.

`just build` and `just test` pass with no `warning:` lines.

Source-breaking, but consumers pin `from:` ranges and this lands as `1.9.0`, so nothing picks it up until each repo opts in.

## Consumer follow-ups

Two consumers reference the renamed case — SimpleF1 (34 sites) and SimpleTrackerForAniList (37). The other five depend on BrzzUtils but never touch `LoadingState`, so they need a version bump at most.

**SimpleTrackerForAniList needs a fix before it bumps** (brzzdev/SimpleTrackerForAniList#302): `LoadStateView.swift:60` only shows the failure when `isEmpty`, but `MediaListFeature.swift:254` and `SocialFeature.swift:126` call `fail(message:)` unconditionally — so `.failed` can sit there with content behind it, and after this change the next refresh would blank it to a full-screen spinner. It needs the `isEmpty` guard SimpleF1 already has.

SimpleF1 gets the payoff: the four spinner branches and the `DriverDetailReducer` workaround that exist only to cover the old transition can go.

Closes #59
Closes #61
