### PR TITLE
feat(LoadingState): add fail(message:ifEmpty:) so consumers stop re-deriving the invariant

### DIFF
--- a/Sources/BrzzUtils/Types/LoadingState.swift
+++ b/Sources/BrzzUtils/Types/LoadingState.swift
@@ -40,4 +40,18 @@ public enum LoadingState: Equatable, Sendable {
 	public mutating func fail(message: String) {
 		self = .failed(message: message)
 	}
+
+	/// Enters `.failed` only when there is nothing on screen; otherwise finishes loading and leaves
+	/// the already-loaded content up.
+	///
+	/// This is the invariant `setLoading(_:)` relies on — that `.failed` is only ever entered with
+	/// nothing to show — expressed as the call consumers actually make on an error path. When there
+	/// is content to keep, `message` is discarded: surfacing it is the caller's job.
+	public mutating func fail(message: String, ifEmpty isEmpty: Bool) {
+		if isEmpty {
+			fail(message: message)
+		} else {
+			setLoading(false)
+		}
+	}
 }

--- a/Tests/BrzzUtilsTests/LoadingStateTests.swift
+++ b/Tests/BrzzUtilsTests/LoadingStateTests.swift
@@ -61,4 +61,33 @@ struct LoadingStateTests {
 		#expect(loadingWithoutContent == .failed(message: "Network error"))
 		#expect(loaded == .failed(message: "Network error"))
 	}
+
+	@Test
+	func failIfEmptyOnlyTakesOverTheScreenWhenThereIsNothingToShow() {
+		// GIVEN
+		var withoutContent = LoadingState.loadingWithoutContent
+		var withContent = LoadingState.refreshing
+
+		// WHEN
+		withoutContent.fail(message: "Network error", ifEmpty: true)
+		withContent.fail(message: "Network error", ifEmpty: false)
+
+		// THEN
+		#expect(withoutContent == .failed(message: "Network error"))
+		#expect(withContent == .loaded)
+	}
+
+	@Test
+	func failIfEmptyOverContentKeepsTheNextReloadInline() {
+		// GIVEN
+		var state = LoadingState.refreshing
+
+		// WHEN
+		state.fail(message: "Network error", ifEmpty: false)
+		state.setLoading(true)
+
+		// THEN
+		// The content is still on screen, so the spinner stays inline rather than taking over.
+		#expect(state == .refreshing)
+	}
 }


### PR DESCRIPTION
`setLoading(true)` sends `.failed` to `.loadingWithoutContent`, which is correct only
given the invariant that `.failed` is entered with nothing on screen. Until now the
library stated that invariant in a doc comment and gave consumers no way to honour it
except by hand, so every error path re-derived the same emptiness check — the same
block, comment included, seven times across SimpleF1 and SimpleTrackerForAniList.

The cost isn't the duplication so much as what happens when a call site skips it: the
symptom shows up one pull-to-refresh later, as a loaded list blanking to a full-screen
spinner. `fail(message:ifEmpty:)` folds the check into the type so the safe call is the
obvious one.

The emptiness predicate stays a caller-supplied `Bool` rather than anything the library
computes, because it varies across call sites — `state.teams.isEmpty`, an optional model
being `nil`, and one compound condition in `StageDetailReducer`.

## Decisions

- **`fail(message:)` stays public and undeprecated.** The issue left this open. Deprecating
  it would warn across every consumer, including screens that genuinely have no content
  concept and are calling it correctly — a lot of noise to close one misuse. Revisit if the
  trap actually bites again.
- **`message` is discarded on the non-empty path**, since there's no failed state to carry
  it. The doc comment now says so; surfacing it is the caller's job.

## Testing

`just test` — full suite green. Three behaviours covered: each branch of the new overload,
and the sequence the invariant protects (fail over content, then `setLoading(true)` lands
on `.refreshing` rather than `.loadingWithoutContent`). Existing tests unmodified.

Purely additive — a minor tag. Migrating the consumers is out of scope; each is a `from:`
bump in its own repo and nothing breaks until they adopt.

Closes #62
