### PR TITLE
refactor(deps): depend on Point-Free libraries directly, not via TCA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,3 @@
-Shared Swift utilities library used across iOS/macOS projects. Includes TCA dependencies, GraphQL helpers, and extensions.
+Shared Swift utilities library used across iOS/macOS projects. Includes swift-dependencies clients, GraphQL helpers, and extensions.
 
 - Build and test via `just build` / `just test` — never call xcodebuild directly

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,26 @@
 
 import PackageDescription
 
+private let ConcurrencyExtras = Target.Dependency.product(
+	name: "ConcurrencyExtras",
+	package: "swift-concurrency-extras",
+)
+
+private let Dependencies = Target.Dependency.product(
+	name: "Dependencies",
+	package: "swift-dependencies",
+)
+
+private let DependenciesMacros = Target.Dependency.product(
+	name: "DependenciesMacros",
+	package: "swift-dependencies",
+)
+
+private let IdentifiedCollections = Target.Dependency.product(
+	name: "IdentifiedCollections",
+	package: "swift-identified-collections",
+)
+
 private let SnapshotTesting = Target.Dependency.product(
 	name: "SnapshotTesting",
 	package: "swift-snapshot-testing",
@@ -10,11 +30,6 @@ private let SnapshotTesting = Target.Dependency.product(
 private let Tagged = Target.Dependency.product(
 	name: "Tagged",
 	package: "swift-tagged",
-)
-
-private let TCA = Target.Dependency.product(
-	name: "ComposableArchitecture",
-	package: "swift-composable-architecture",
 )
 
 let package = Package(
@@ -37,8 +52,16 @@ let package = Package(
 	],
 	dependencies: [
 		.package(
-			url: "https://github.com/pointfreeco/swift-composable-architecture",
-			from: "1.26.1",
+			url: "https://github.com/pointfreeco/swift-concurrency-extras",
+			from: "1.4.1",
+		),
+		.package(
+			url: "https://github.com/pointfreeco/swift-dependencies",
+			from: "1.14.1",
+		),
+		.package(
+			url: "https://github.com/pointfreeco/swift-identified-collections",
+			from: "1.1.1",
 		),
 		.package(
 			url: "https://github.com/pointfreeco/swift-snapshot-testing",
@@ -64,8 +87,11 @@ let package = Package(
 		.target(
 			name: "BrzzUtils",
 			dependencies: [
+				ConcurrencyExtras,
+				Dependencies,
+				DependenciesMacros,
+				IdentifiedCollections,
 				Tagged,
-				TCA,
 			],
 		),
 		.testTarget(

--- a/Sources/BrzzUtils/Dependencies/Dep+OSLogStore.swift
+++ b/Sources/BrzzUtils/Dependencies/Dep+OSLogStore.swift
@@ -1,4 +1,5 @@
-public import ComposableArchitecture
+public import Dependencies
+import DependenciesMacros
 public import OSLog
 
 extension DependencyValues {

--- a/Sources/BrzzUtils/Extensions/Ext+Color.swift
+++ b/Sources/BrzzUtils/Extensions/Ext+Color.swift
@@ -1,4 +1,3 @@
-import Dependencies
 public import SwiftUI
 
 extension Color {

--- a/docs/adr/0001-no-composable-architecture-dependency.md
+++ b/docs/adr/0001-no-composable-architecture-dependency.md
@@ -1,0 +1,68 @@
+# 1. No ComposableArchitecture dependency
+
+Date: 2026-08-02
+
+## Status
+
+Accepted
+
+## Context
+
+BrzzUtils depended on `swift-composable-architecture` and, through it, resolved
+`Dependencies`, `DependenciesMacros`, `IdentifiedCollections`, and `ConcurrencyExtras`
+transitively — importing all four without ever declaring them.
+
+It never used TCA itself. There were no reducers, stores, `TestStore`s, effects, or
+navigation anywhere in `Sources`. The single file that imported `ComposableArchitecture`
+(`Dep+OSLogStore.swift`) reached only `DependencyValues`, `DependencyKey`, and
+`@DependencyClient` — all of which belong to swift-dependencies. TCA was, in effect, an
+expensive way to spell `import Dependencies`.
+
+That became load-bearing when the consuming apps wanted to adopt
+[ComposableArchitecture 2.0](https://github.com/pointfreeco/TCA26). At the time of writing
+TCA26 has no tags or releases — only `main` — and it pulls three further branch
+dependencies of its own (swift-case-paths `26`, swift-clocks `clocks-2`, swift-navigation
+`relax-sendable`). SwiftPM does not allow a version-resolved package to depend on a
+branch, so pointing BrzzUtils at TCA26 would have forced every consuming app to pin
+BrzzUtils by branch or revision too, ending its ability to ship stable tags. It would also
+have raised the platform floor from iOS 16 / macOS 13 to iOS 17 / macOS 14, in exchange for
+capabilities this package has no code to use.
+
+## Decision
+
+BrzzUtils does not depend on ComposableArchitecture. It depends directly on the underlying
+Point-Free libraries it actually uses:
+
+- `swift-dependencies` (`Dependencies`, `DependenciesMacros`)
+- `swift-identified-collections`
+- `swift-concurrency-extras`
+
+## Consequences
+
+BrzzUtils is TCA-version-agnostic. It works unchanged under TCA 1.x, under TCA26's
+`ComposableArchitecture1` compatibility layer, and alongside `ComposableArchitecture2` — so
+each app adopts TCA 2.0 on its own schedule while BrzzUtils keeps releasing stable SemVer
+tags.
+
+It is also insulated from TCA26's trait system. `ComposableArchitecture2` only vends
+`Dependencies` when the consumer enables the `Dependencies` trait, which is **off** by
+default (`.default(enabledTraits: ["ComposableArchitecture1Deprecations"])`), and it does
+not vend `IdentifiedCollections` or `ConcurrencyExtras` at all. Declaring these packages
+directly means BrzzUtils compiles regardless of how any app configures its traits.
+
+The platform floor stays at iOS 16 / macOS 13, and the resolved dependency graph drops from
+16 pins to 11.
+
+**Do not add `swift-composable-architecture` (or TCA26) back.** Re-adding it looks like a
+simplification — one dependency instead of three, and it re-exports everything — but it
+silently re-couples this library's release model to whatever the apps happen to be tracking.
+If a new utility genuinely needs a TCA type, that is a signal the utility belongs in an app,
+not here.
+
+## Revisit when
+
+An app migrates to pure `ComposableArchitecture2` and declines to enable the `Dependencies`
+trait. At that point `Dep+UserDefaults`, `Dep+OSLogStore`, and `Ext+Date` would drag
+swift-dependencies into an app that deliberately shed it, and the answer is a default-on
+SwiftPM trait guarding those files — not a target split, and not a return to TCA. Deferred
+until a real consumer wants it, because only then will the seam be known.

--- a/docs/adr/0001-no-composable-architecture-dependency.md
+++ b/docs/adr/0001-no-composable-architecture-dependency.md
@@ -19,14 +19,19 @@ navigation anywhere in `Sources`. The single file that imported `ComposableArchi
 expensive way to spell `import Dependencies`.
 
 That became load-bearing when the consuming apps wanted to adopt
-[ComposableArchitecture 2.0](https://github.com/pointfreeco/TCA26). At the time of writing
-TCA26 has no tags or releases — only `main` — and it pulls three further branch
-dependencies of its own (swift-case-paths `26`, swift-clocks `clocks-2`, swift-navigation
-`relax-sendable`). SwiftPM does not allow a version-resolved package to depend on a
-branch, so pointing BrzzUtils at TCA26 would have forced every consuming app to pin
-BrzzUtils by branch or revision too, ending its ability to ship stable tags. It would also
-have raised the platform floor from iOS 16 / macOS 13 to iOS 17 / macOS 14, in exchange for
-capabilities this package has no code to use.
+[ComposableArchitecture 2.0](https://github.com/pointfreeco/TCA26).
+
+> **Observed on TCA26 `main`, 2026-08-02.** TCA26 is branch-only and moving; every
+> specific claim about it in this ADR is a snapshot of that day, not a standing fact.
+> Re-check upstream before relying on any of them.
+
+As of that date TCA26 has no tags or releases — only `main` — and it pulls three further
+branch dependencies of its own (swift-case-paths `26`, swift-clocks `clocks-2`,
+swift-navigation `relax-sendable`). SwiftPM does not allow a version-resolved package to
+depend on a branch, so pointing BrzzUtils at TCA26 would have forced every consuming app to
+pin BrzzUtils by branch or revision too, ending its ability to ship stable tags. It also
+declared a platform floor of iOS 17 / macOS 14, raising ours from iOS 16 / macOS 13 in
+exchange for capabilities this package has no code to use.
 
 ## Decision
 
@@ -44,11 +49,14 @@ BrzzUtils is TCA-version-agnostic. It works unchanged under TCA 1.x, under TCA26
 each app adopts TCA 2.0 on its own schedule while BrzzUtils keeps releasing stable SemVer
 tags.
 
-It is also insulated from TCA26's trait system. `ComposableArchitecture2` only vends
-`Dependencies` when the consumer enables the `Dependencies` trait, which is **off** by
-default (`.default(enabledTraits: ["ComposableArchitecture1Deprecations"])`), and it does
-not vend `IdentifiedCollections` or `ConcurrencyExtras` at all. Declaring these packages
-directly means BrzzUtils compiles regardless of how any app configures its traits.
+It is also insulated from TCA26's trait system. On `main` as of 2026-08-02,
+`ComposableArchitecture2` only vends `Dependencies` when the consumer enables the
+`Dependencies` trait, which is **off** by default — the manifest declares
+`.default(enabledTraits: ["ComposableArchitecture1Deprecations"])` — and it does not vend
+`IdentifiedCollections` or `ConcurrencyExtras` at all. Trait names and defaults are exactly
+the kind of thing that changes on an untagged branch; the reason to declare these packages
+directly is that doing so makes BrzzUtils compile regardless of how any app configures its
+traits, whatever those traits end up being called.
 
 The platform floor stays at iOS 16 / macOS 13, and the resolved dependency graph drops from
 16 pins to 11.
@@ -62,7 +70,8 @@ not here.
 ## Revisit when
 
 An app migrates to pure `ComposableArchitecture2` and declines to enable the `Dependencies`
-trait. At that point `Dep+UserDefaults`, `Dep+OSLogStore`, and `Ext+Date` would drag
+trait. At that point the four files that import `Dependencies` — `Dep+OSLogStore`,
+`Dep+UserDefaults`, `Dep+UserDefaultsProvider`, and `Ext+Date` — would drag
 swift-dependencies into an app that deliberately shed it, and the answer is a default-on
 SwiftPM trait guarding those files — not a target split, and not a return to TCA. Deferred
 until a real consumer wants it, because only then will the seam be known.


### PR DESCRIPTION
## What changed

BrzzUtils no longer depends on `swift-composable-architecture`. It now declares the three Point-Free libraries it actually uses — `swift-dependencies`, `swift-identified-collections`, `swift-concurrency-extras` — directly.

The package's own API is unchanged. The one file that imported `ComposableArchitecture` only ever reached `DependencyValues`, `DependencyKey`, and `@DependencyClient`, all of which belong to swift-dependencies; it now imports that instead. Four modules that were being imported without ever being declared, resolving transitively through TCA, are now explicit.

## Why

The consuming apps want to adopt [ComposableArchitecture 2.0](https://github.com/pointfreeco/TCA26), which is branch-only with no tags. SwiftPM won't let a version-resolved package depend on a branch, so pointing BrzzUtils at it would force every consuming app to pin BrzzUtils by branch too, ending its ability to ship stable tags — and would raise the platform floor to iOS 17 in exchange for capabilities this package has no code to use. There are no reducers, stores, `TestStore`s, effects, or navigation anywhere in `Sources`.

Depending on the underlying libraries directly makes BrzzUtils TCA-version-agnostic: it works under TCA 1.x, under TCA26's `ComposableArchitecture1` layer, and alongside `ComposableArchitecture2`, so each app migrates on its own schedule. ADR 0001 records the constraint and the condition that would revisit it.

## Things to look out for

- **This is a minor bump (1.10.0), not a major.** `Dep+OSLogStore.swift`'s `public import` narrows from `ComposableArchitecture` to `Dependencies`. Nothing reachable is removed — BrzzUtils' public API only ever names Dependencies types — and every consumer checked already declares TCA itself. Flagging it because the call was deliberate and the blast radius wasn't verified by building all 8 consuming apps.
- **Platform floor deliberately unchanged** at iOS 16 / macOS 13.
- **No tag in this PR.** 1.10.0 gets tagged after merge.
- ADR 0001 makes time-stamped claims about TCA26 `main` as of 2026-08-02. It's branch-only and moving; the ADR says so explicitly.

## Test plan

- [x] `just build` — Build Succeeded
- [x] `just test` — all suites pass, zero warnings
- [x] Resolved graph drops 16 pins → 11, losing `swift-composable-architecture` and its TCA-only transitives (`swift-case-paths`, `swift-navigation`, `swift-perception`, `swift-sharing`)
- [x] Each of the three new direct dependencies confirmed to have a real call site
